### PR TITLE
Minor fixes

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -46,3 +46,7 @@ copyright = "© tommos.co.uk 2025"
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]
+
+[minify]
+  disableXML = true
+  minifyOutput = true

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,0 +1,66 @@
+{{- with .cxt}} {{/* Apply proper context from dict */}}
+{{- if (and .Params.cover.image (not $.isHidden)) }}
+<figure class="entry-cover">
+    {{- $loading := cond $.IsSingle "eager" "lazy" }}
+    {{- $addLink := (and site.Params.cover.linkFullImages $.IsSingle) }}
+    {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
+    {{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
+    {{- $responsiveImages := (.Params.cover.responsiveImages | default site.Params.cover.responsiveImages) | default true }}
+
+    {{- $pageBundleCover := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $globalResourcesCover := (resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $cover := (or $pageBundleCover $globalResourcesCover)}}
+    {{- /* We are not using the .Param.cover.relative to decide the location of image */}}
+    {{- /* If we have the image in pageBundle or globalResources we can process the image */}}
+
+    {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
+    {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
+    {{- if hugo.IsExtended -}}
+        {{- $processableFormats = $processableFormats | append "webp" -}}
+    {{- end -}}
+
+    {{- $imgdl := (.Params.cover.image) | absURL }}
+    {{- if $cover -}}
+        {{- $imgdl = $cover.Permalink }}
+    {{- end -}}
+
+    {{- if $addLink }}
+        <a href="{{ $imgdl }}" target="_blank" rel="noopener noreferrer">
+    {{- end }}
+
+    {{- if $cover -}}
+        {{/* i.e it is present in page bundle */}}
+        {{- if (and (in $processableFormats $cover.MediaType.SubType) ($responsiveImages) (eq $prod true)) }}
+            <img loading="{{$loading}}"
+                {{ if $.IsSingle }}fetchpriority="high"{{ end }}
+                srcset='{{- range $size := $sizes -}}
+                            {{- if (ge $cover.Width $size) }}
+                                {{- printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw," $size) }}
+                            {{- end }}
+                        {{- end }}
+                        {{- printf "%s %dw" ($cover.Permalink) ($cover.Width) }}'
+                src="{{ $cover.Permalink }}"
+                sizes="(min-width: 768px) 720px, 100vw"
+                width="{{ $cover.Width }}" height="{{ $cover.Height }}"
+                alt="{{ $alt }}">
+        {{- else }}{{/* Unprocessable image or responsive images disabled */}}
+            <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
+        {{- end }}
+    {{- else }}
+        {{- /* For absolute urls and external links, no img processing here */}}
+        <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
+    {{- end }}
+
+    {{- if $addLink }}
+        </a>
+    {{- end -}}
+
+    {{- /*  Display Caption  */}}
+    {{- if $.IsSingle }}
+        {{ with .Params.cover.caption -}}
+            <figcaption>{{ . | markdownify }}</figcaption>
+        {{- end }}
+    {{- end }}
+</figure>
+{{- end }}{{/* End image */}}
+{{- end -}}{{/* End context */ -}}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -3,15 +3,15 @@
 {{- $caption := .Get "caption" | default "" -}}
 
 {{- if $img -}}
-  {{- $tinyw := $img.Fill "320x320 webp" -}}
-  {{- $smallw := $img.Fill "640x640 webp" -}}
-  {{- $mediumw := $img.Fill "1024x1024 webp" -}}
-  {{- $largew := $img.Fill "1600x1600 webp" -}}
+  {{- $tinyw := $img.Resize "320x webp" -}}
+  {{- $smallw := $img.Resize "640x webp" -}}
+  {{- $mediumw := $img.Resize "1024x webp" -}}
+  {{- $largew := $img.Resize "1600x webp" -}}
   
-  {{- $tiny := $img.Fill "320x320" -}}
-  {{- $small := $img.Fill "640x640" -}}
-  {{- $medium := $img.Fill "1024x1024" -}}
-  {{- $large := $img.Fill "1600x1600" -}}
+  {{- $tiny := $img.Resize "320x" -}}
+  {{- $small := $img.Resize "640x" -}}
+  {{- $medium := $img.Resize "1024x" -}}
+  {{- $large := $img.Resize "1600x" -}}
 
   <figure>
     <picture>


### PR DESCRIPTION
This pull request introduces significant improvements to image handling and site output optimization in the Hugo site. The main focus is on enhancing image processing for responsive design, optimizing HTML output, and refining the image shortcode logic.

**Image handling improvements:**

* Added a new `cover.html` partial that intelligently selects and processes cover images from page bundles or global resources, generates responsive image sets, and supports linking to full-size images. The implementation ensures proper alt text, caption handling, and optimized loading based on context.
* Updated the `img.html` shortcode to use the `Resize` method instead of `Fill` for generating various image sizes, which simplifies the image processing logic and may improve compatibility and performance.

**Site output optimization:**

* Enabled HTML minification and disabled XML minification in the `hugo.toml` configuration, which will help reduce the size of generated HTML files and improve site loading speed.